### PR TITLE
Add `start_from` in File

### DIFF
--- a/putio/files.go
+++ b/putio/files.go
@@ -35,7 +35,7 @@ type File struct {
 	Icon              string `json:"icon"`
 	CRC32             string `json:"crc32"`
 	IsShared          bool   `json:"is_shared"`
-	StartFrom         int64  `json:"start_from"`
+	StartFrom         int    `json:"start_from"`
 }
 
 func (f *File) String() string {

--- a/putio/files.go
+++ b/putio/files.go
@@ -35,6 +35,7 @@ type File struct {
 	Icon              string `json:"icon"`
 	CRC32             string `json:"crc32"`
 	IsShared          bool   `json:"is_shared"`
+	StartFrom         int64  `json:"start_from"`
 }
 
 func (f *File) String() string {


### PR DESCRIPTION
Although not listed in the offical API, `start_from` is included and
contains valuable about when a video should play form